### PR TITLE
Fix env loading and cleanup

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Union
 
+from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -22,6 +23,9 @@ logger = logging.getLogger(__name__)
 set_log_level("INFO")
 
 app = FastAPI(title="Gemini API FastAPI Server")
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 # Add CORS middleware
 app.add_middleware(
@@ -197,7 +201,7 @@ async def list_models():
         }
         for m in Model
     ]
-    print(data)
+    logger.debug(f"Model list: {data}")
     return {"object": "list", "data": data}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "browser-cookie3>=0.20.1",
     "fastapi>=0.115.12",
     "gemini-webapi>=1.12.1",
+    "python-dotenv>=1.0.1",
     "uvicorn>=0.34.1",
     "uvloop>=0.21.0",
 ]


### PR DESCRIPTION
## Summary
- automatically load environment variables from `.env`
- log model list instead of printing
- declare `python-dotenv` dependency

## Testing
- `ruff check .`
- `ruff format .`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850c24ff4dc832bb5f09af77e435e7d